### PR TITLE
Saving CEP before Address

### DIFF
--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/service/UserService.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/service/UserService.java
@@ -219,18 +219,18 @@ public class UserService {
         Cep cep = cepRepository.findById(userDTO.cep())
                 .orElseGet(() -> {
                     Cep newCep = new Cep();
-
                     newCep.setCepId(userDTO.cep());
                     newCep.setStreet(userDTO.street());
                     newCep.setCity(userDTO.city());
                     newCep.setState(userDTO.state());
+                    cepRepository.save(newCep);
+
                     return newCep;
                 });
 
         address.setCep(cep);
         userRepository.save(user);
         addressRepository.save(address);
-        cepRepository.save(cep);
 
         return new UpdateUserResponseDTO(
                 user.getName(),

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/service/UserService.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/service/UserService.java
@@ -36,8 +36,11 @@ public class UserService {
         User user = signUpUserDTO.toUser();
         user = userRepository.save(user);
 
-        Cep cep = signUpUserDTO.toCep();
-        cep = cepRepository.save(cep);
+        Cep cep = cepRepository.findById(signUpUserDTO.cep())
+                .orElseGet(() -> {
+                    Cep newCep = signUpUserDTO.toCep();
+                    return cepRepository.save(newCep);
+                });
 
         Address address = signUpUserDTO.toAddress(user, cep);
         addressRepository.save(address);


### PR DESCRIPTION
# Salvando CEP antes de salvar o Endereço
<!-- Preencha o texto acima com o título do PR -->
[Tarefa relacionada](https://trello.com/c/844UiUmF/88-criar-endpoints-de-atualiza%C3%A7%C3%A3o-de-usu%C3%A1rio)

## Descrição
### Objetivo
Foi identificado um problema ao atualizar o CEP de um usuário ou ao cadastrar um novo usuário. Se o usuário fornecesse um CEP que não existisse no banco de dados, a API falhava ao associar esse CEP à entidade de Endereço. O mesmo problema ocorria durante o cadastro, onde o CEP fornecido não era salvo antes da associação com o endereço.

### Solução
Para resolver esse problema, a abordagem foi ajustada para salvar a entidade CEP imediatamente após sua criação. Além disso, se o CEP fornecido já existir no banco de dados, ele será associado ao endereço sem a necessidade de criar um novo registro. Com essas mudanças, garantimos que o CEP esteja corretamente associado ao Endereço, seja ele novo ou existente, evitando erros relacionados a dados não salvos.

## Checklist
<!-- Mantenha apenas o ícone que representa o cumprimento ou não cumprimento do requisito -->
|     | Requisito                                                              |
| --- | ---------------------------------------------------------------------- |
|✅| Testei extensivamente meu recurso                                      |
|✅| Minhas alterações seguem as boas práticas de código                    |
|✅| Minhas alterações não geram erros, bugs ou excessões inesperadas       |
|✅| O código está legível e documentado                                    |
|✅| Minhas alterações atendem aos requisitos de negócio exigidos na tarefa |
|❌| Houve necessidade de modificações nas dependências                     |