### PR TITLE
Update pantry after rate recipe

### DIFF
--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/controller/UserController.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/controller/UserController.java
@@ -123,7 +123,4 @@ public class UserController implements UserContract {
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
-
-
-
 }

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/dto/pantry/query/PantryItemWithAvailabilityDTO.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/dto/pantry/query/PantryItemWithAvailabilityDTO.java
@@ -1,0 +1,9 @@
+package com.ottistech.indespensa.api.ms_indespensa.dto.pantry.query;
+
+import com.ottistech.indespensa.api.ms_indespensa.model.PantryItem;
+
+public record PantryItemWithAvailabilityDTO(
+        PantryItem pantryItem,
+        boolean isInPantry
+) {
+}

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/dto/pantry/response/PantryItemDetailsDTO.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/dto/pantry/response/PantryItemDetailsDTO.java
@@ -42,6 +42,9 @@ public record PantryItemDetailsDTO(
         Integer amount,
 
         @Schema(description = "Expiration date of the pantry item", example = "2024-12-31")
-        LocalDate validityDate
+        LocalDate validityDate,
+
+        @Schema(description = "Flag indicating if product was already used by user", example = "false")
+        Boolean wasOpened
 ) {
 }

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/dto/pantry/response/PantryItemResponseDTO.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/dto/pantry/response/PantryItemResponseDTO.java
@@ -52,7 +52,10 @@ public record PantryItemResponseDTO(
         LocalDate pantryItemPurchaseDate,
 
         @Schema(description = "Indicates whether the pantry item is currently active", example = "true")
-        Boolean pantryItemIsActive
+        Boolean pantryItemIsActive,
+
+        @Schema(description = "Flag indicating if product was already used by user", example = "false")
+        Boolean wasOpened
 ) {
 
     public static PantryItemResponseDTO fromPantryItem(PantryItem pantryItem) {
@@ -71,7 +74,8 @@ public record PantryItemResponseDTO(
                 pantryItem.getAmount(),
                 pantryItem.getValidityDate(),
                 pantryItem.getPurchaseDate(),
-                pantryItem.getIsActive()
+                pantryItem.getIsActive(),
+                pantryItem.getWasOpened()
         );
     }
 }

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/dto/recipe/response/RecipeFullInfoResponseDTO.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/dto/recipe/response/RecipeFullInfoResponseDTO.java
@@ -51,6 +51,7 @@ public record RecipeFullInfoResponseDTO(
                         ingredient.getAmount(),
                         ingredient.getUnit(),
                         ingredient.getIsEssential(),
+                        null,
                         null
                 ))
                 .collect(Collectors.toList());

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/dto/recipe_ingredient/response/RecipeIngredientDetailsDTO.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/dto/recipe_ingredient/response/RecipeIngredientDetailsDTO.java
@@ -23,6 +23,9 @@ public record RecipeIngredientDetailsDTO(
         Boolean isEssential,
 
         @Schema(description = "Indicates if the ingredient is available in the user's pantry", example = "false")
-        Boolean isInPantry
+        Boolean isInPantry,
+
+        @Schema(description = "Flag indicating if product was already used by user", example = "false")
+        Boolean wasOpened
 ) {
 }

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/model/PantryItem.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/model/PantryItem.java
@@ -43,6 +43,9 @@ public class PantryItem {
     @Column(name = "is_active")
     private Boolean isActive = Boolean.FALSE;
 
+    @Column(name = "was_opened")
+    private Boolean wasOpened = Boolean.FALSE;
+
     public PantryItem(User user, Product product) {
         this.user = user;
         this.product = product;

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/repository/FoodRepository.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/repository/FoodRepository.java
@@ -10,5 +10,9 @@ import java.util.Optional;
 public interface FoodRepository extends JpaRepository<Food, Long> {
 
     @Query("SELECT f FROM Food f WHERE LOWER(f.foodName) = LOWER(:foodName)")
-    Optional<Food> findByFoodName(@Param("foodName") String alias);
+    Optional<Food> findByFoodName(
+            @Param("foodName")
+            String alias
+    );
+
 }

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/repository/RecipeIngredientRepository.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/repository/RecipeIngredientRepository.java
@@ -21,6 +21,11 @@ public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredie
         CASE
             WHEN COUNT(DISTINCT pi) > 0 THEN TRUE
             ELSE FALSE
+        END,
+        CASE
+           WHEN COUNT(pi) > 0 THEN
+                CASE WHEN SUM(CASE WHEN pi.wasOpened THEN 1 ELSE 0 END) > 0 THEN TRUE ELSE FALSE END
+           ELSE FALSE
         END
     )
     FROM Recipe r
@@ -31,9 +36,19 @@ public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredie
         AND pi.amount > 0
         AND pi.isActive = TRUE
     WHERE r.recipeId = :recipeId
-    GROUP BY ri.ingredientFood.foodId, ri.ingredientFood.foodName, ri.amount, ri.unit, ri.isEssential
+    GROUP BY
+        ri.ingredientFood.foodId,
+        ri.ingredientFood.foodName,
+        ri.amount,
+        ri.unit,
+        ri.isEssential
     """)
-    List<RecipeIngredientDetailsDTO> findIngredientsByRecipeId(@Param("recipeId") Long recipeId, @Param("user") User user);
+    List<RecipeIngredientDetailsDTO> findIngredientsByRecipeId(
+            @Param("recipeId")
+            Long recipeId,
 
+            @Param("user")
+            User user
+    );
 
 }

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/repository/RecipeRepository.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/repository/RecipeRepository.java
@@ -149,4 +149,5 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
             @Param("user") User user,
             Pageable pageable
     );
+
 }

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/service/RecipeService.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/service/RecipeService.java
@@ -114,8 +114,6 @@ public class RecipeService {
 
         List<RecipeIngredientDetailsDTO> ingredientDetails = ingredientRepository.findIngredientsByRecipeId(recipeId, user);
 
-        ingredientDetails.forEach(System.out::println);
-
         return RecipeDetailsDTO.fromPartialResponseDTO(recipe, ingredientDetails);
     }
 

--- a/src/main/java/com/ottistech/indespensa/api/ms_indespensa/service/RecipeService.java
+++ b/src/main/java/com/ottistech/indespensa/api/ms_indespensa/service/RecipeService.java
@@ -5,8 +5,8 @@ import com.ottistech.indespensa.api.ms_indespensa.dto.recipe.request.CreateRecip
 import com.ottistech.indespensa.api.ms_indespensa.dto.recipe.request.RateRecipeRequestDTO;
 import com.ottistech.indespensa.api.ms_indespensa.dto.recipe.response.RecipeDetailsDTO;
 import com.ottistech.indespensa.api.ms_indespensa.dto.recipe.response.RecipeFullInfoResponseDTO;
-import com.ottistech.indespensa.api.ms_indespensa.dto.recipe_ingredient.response.RecipeIngredientDetailsDTO;
 import com.ottistech.indespensa.api.ms_indespensa.dto.recipe.response.RecipePartialResponseDTO;
+import com.ottistech.indespensa.api.ms_indespensa.dto.recipe_ingredient.response.RecipeIngredientDetailsDTO;
 import com.ottistech.indespensa.api.ms_indespensa.model.*;
 import com.ottistech.indespensa.api.ms_indespensa.repository.*;
 import com.ottistech.indespensa.api.ms_indespensa.utils.enums.Availability;
@@ -19,7 +19,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,4 @@ spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 spring.data.redis.ssl.enabled=true
 springdoc.swagger-ui.path=/docs
+server.error.include-stacktrace=never


### PR DESCRIPTION
# Atualizar despensa pós avaliação da receita
<!-- Preencha o texto acima com o título do PR -->
[Tarefa relacionada](https://trello.com/c/nEDmpHml/173-atualizar-despensa-p%C3%B3s-avalia%C3%A7%C3%A3o-da-receita)

## Descrição
### Objetivo
Fazer com que o fluxo de avaliação/fazer receite funcione de uma forma aceitável

### Solução
Criação de um novo campo na tabela pantry_items (PantryItem) chamado was_opened, indicando se o usuário já utilizou parte daquele produto em alguma receita avaliada/feita pelo mesmo. Também foi alterado queries e DTO's que precisavam adicionar esse novo campo

## Checklist
<!-- Mantenha apenas o ícone que representa o cumprimento ou não cumprimento do requisito -->
|     | Requisito                                                              |
| --- | ---------------------------------------------------------------------- |
|✅| Testei extensivamente meu recurso                                      |
|✅| Minhas alterações seguem as boas práticas de código                    |
|✅| Minhas alterações não geram erros, bugs ou excessões inesperadas       |
|✅| O código está legível e documentado                                    |
|✅| Minhas alterações atendem aos requisitos de negócio exigidos na tarefa |
|❌| Houve necessidade de modificações nas dependências                     |

## Observações
<!-- Adicione aqui informações relevantes e outros links úteis -->.

